### PR TITLE
Update README.md to specify react-native link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The Rating Requestor is a very simple JS module that you simply instantiate and 
 ## Installation
 
     npm i --save react-native-rating-requestor@github:rizzomichaelg/react-native-rating-requestor
+    
+    react-native link react-native-rating-requestor
 
 ## Usage
 


### PR DESCRIPTION
If you don't run `react-native link`, the native iOS review popup will not get used in your app. You have to run this command to link in that functionality.